### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+    contents: read
+
 on:
     push:
         branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/dustfeather/filelist-ext/security/code-scanning/1](https://github.com/dustfeather/filelist-ext/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes the workflow needs. This can be placed at the root (applies to all jobs) or under the specific job. The current workflow only checks out code, installs dependencies, builds, and uploads an artifact; none of these require write access to repository contents, so `contents: read` is sufficient.

The best minimal fix without changing functionality is to add a root-level `permissions` block just after the `name:` line (or before `jobs:`). This will apply to the `build` job and any future jobs unless they override it. Concretely, in `.github/workflows/build.yml`, add:

```yml
permissions:
    contents: read
```

at the top level, aligned with `on:` and `jobs:`. No additional methods, imports, or definitions are needed, and no existing steps need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
