### PR TITLE
chore(deps): bump GitHub Actions (consolidated)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v5
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: pnpm/action-setup@v5
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10
 
@@ -87,7 +87,7 @@ jobs:
               run: git archive --format=zip --prefix=source/ -o source-${{ steps.version.outputs.tag }}.zip HEAD
 
             - name: Create GitHub Release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3
               with:
                   tag_name: ${{ steps.version.outputs.tag }}
                   generate_release_notes: true
@@ -96,7 +96,7 @@ jobs:
                       filelist-tv-monitor-firefox-${{ steps.version.outputs.tag }}.xpi
 
             - name: Upload artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: extensions
                   path: |
@@ -109,7 +109,7 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               with:
                   name: extensions
 
@@ -169,7 +169,7 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               with:
                   name: extensions
 


### PR DESCRIPTION
## Summary
Consolidates Dependabot PRs #30, #31, #32 into a single bump to avoid sequential CI churn and multiple releases.

### Action bumps
| Action | From | To | Notes |
|--------|------|----|----|
| `pnpm/action-setup` | v5 | v6 | Adds pnpm v11 support; we stay pinned to v10 (no behavior change) |
| `softprops/action-gh-release` | v2 | v3 | Node 20 → 24 runtime; repo already opted in via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` |
| `actions/download-artifact` (release.yml) | v4 | v8 | ESM migration, hash mismatches now error by default |
| `actions/upload-artifact` (release.yml) | v4 | v7 | Aligns with build.yml; pairs cleanly with download v8 |

The `upload-artifact@v4 → v7` bump in release.yml isn't from a Dependabot PR but is included so the release flow's upload/download pair stays consistent (build.yml was already at v7).

## Test plan
- [x] CI passes on consolidated branch
- [ ] Next release exercises the upload-artifact → download-artifact path (publish-chrome / publish-firefox)