### PR TITLE
fix(ci): make AMO publish-firefox honor Retry-After header and surface diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,9 @@ jobs:
               with:
                   name: extensions
 
+            - name: Stagger AMO publish to avoid 3/min user throttle
+              run: sleep $(( RANDOM % 60 ))
+
             - uses: actions/setup-node@v6
               with:
                   node-version: 22
@@ -199,28 +202,42 @@ jobs:
                     "
                   }
 
-                  # Retry wrapper for 429 rate limits (up to 3 attempts, max 120s wait)
+                  # Retry wrapper for 429 rate limits. Reads Retry-After from the
+                  # HTTP header (DRF returns it there, not in the JSON body) and
+                  # routes diagnostics to stderr so they survive $() capture.
                   amo_curl() {
-                    for attempt in 1 2 3; do
-                      JWT=$(generate_jwt)
-                      RESPONSE=$(curl -s -w "\n%{http_code}" -H "Authorization: JWT $JWT" "$@")
-                      HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-                      if [ "$HTTP_CODE" = "429" ]; then
-                        RETRY_AFTER=$(echo "$RESPONSE" | sed '$d' | jq -r '.retry_after // 30')
-                        if [ "$RETRY_AFTER" -gt 120 ] 2>/dev/null; then
-                          echo "Rate limited (429) but retry_after=${RETRY_AFTER}s exceeds 120s cap, giving up"
-                          echo "$RESPONSE"
-                          return 1
-                        fi
-                        echo "Rate limited (429), retrying in ${RETRY_AFTER}s (attempt $attempt/3)"
-                        sleep "$RETRY_AFTER"
-                      else
-                        echo "$RESPONSE"
-                        return 0
-                      fi
-                    done
-                    echo "$RESPONSE"
-                    return 1
+                      local headers_file response http_code retry_after
+                      headers_file=$(mktemp)
+                      trap 'rm -f "$headers_file"' RETURN
+
+                      for attempt in 1 2 3 4 5; do
+                          local jwt
+                          jwt=$(generate_jwt)
+                          response=$(curl -sS -D "$headers_file" -w "\n%{http_code}" \
+                                         -H "Authorization: JWT $jwt" "$@" || true)
+                          http_code=$(echo "$response" | tail -1)
+
+                          if [ "$http_code" != "429" ]; then
+                              echo "$response"
+                              return 0
+                          fi
+
+                          retry_after=$(grep -i '^retry-after:' "$headers_file" \
+                                        | tail -1 | awk '{print $2}' | tr -d '\r')
+                          : "${retry_after:=60}"
+                          if [ "$retry_after" -gt 90 ] 2>/dev/null; then
+                              echo "amo_curl: retry-after ${retry_after}s exceeds 90s cap, giving up" >&2
+                              echo "$response" >&2
+                              return 1
+                          fi
+
+                          echo "amo_curl: 429 throttled, sleeping ${retry_after}s (attempt $attempt/5)" >&2
+                          sleep "$retry_after"
+                      done
+
+                      echo "amo_curl: exhausted 5 retries. Final response:" >&2
+                      echo "$response" >&2
+                      return 1
                   }
 
                   AMO_BASE="https://addons.mozilla.org/api/v5"


### PR DESCRIPTION
## Summary

The `publish-firefox` job was failing silently on AMO 429 throttles (e.g. v1.0.48 release) for two compounding reasons:

1. **Diagnostics were swallowed by command substitution.** `amo_curl` is called as `VAR=$(amo_curl ...)`, so every `echo "Rate limited..."` and the final response body went into the variable instead of the job log. When the helper `return 1`d, `bash -e` killed the step before the caller could `echo "Version create ($HTTP_CODE): $BODY"`.
2. **Wrong source for `Retry-After`.** The helper did `jq -r '.retry_after // 30'` against the response body, but DRF returns `Retry-After` as an HTTP header, not a JSON field. The expression always fell back to 30, producing 3 x 30s = ~90s of silence then `exit 1`.

Per `mozilla/addons-server` `src/olympia/api/throttling.py`, `POST /addons/addon/{id}/versions/` is throttled per-user at 3/minute (burst), with the counter incremented only on **successful** requests, so a 429-and-immediate-retry within the same minute can never win — we need to wait out the burst window.

## Changes

- Replace the `amo_curl` body in `.github/workflows/release.yml`:
  - Capture response headers with `curl -D` and parse `Retry-After` from there.
  - Route every diagnostic to stderr (`>&2`) so it survives `$()` capture.
  - Bump the attempt budget to 5 with a 90s per-attempt cap (covers the 1-minute burst window plus headroom).
  - Echo the final response to stderr before returning non-zero so a `set -e` death still leaves a forensic trail.
  - Function still writes `body\nhttp_code` to stdout on success; existing callers (`tail -1`, `sed '$d'`) keep working unchanged.
- Add a `Stagger AMO publish to avoid 3/min user throttle` step (`sleep $(( RANDOM % 60 ))`) at the top of the `publish-firefox` job so concurrent releases across our extension repos self-stagger past the per-user throttle.

No other behavioral changes; the existing `generate_jwt` function is reused.

Closes #45

## Test plan

- [ ] Validate workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — done locally, exit 0).
- [ ] Next release run on `main` should either succeed quietly or, on 429, log `amo_curl: 429 throttled, sleeping <Ns> (attempt N/5)` lines that survive into the job log.
- [ ] If all 5 attempts are exhausted, the final response body should be visible on stderr in the job log instead of silent `exit 1`.