### PR TITLE
ci: skip claude-review on .github/** PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary

- Adds `paths-ignore: ['.github/**']` to the `pull_request:` trigger of `.github/workflows/claude-code-review.yml`.
- Aligns filelist-ext with the existing pattern in `dustfeather/discord-purge` and `dustfeather/uninsta`.

## Why

`anthropics/claude-code-action@v1` issues an app token via OIDC and validates that the workflow file on the PR branch is byte-identical to the version on the default branch. When a PR modifies a workflow file that invokes the action (for example, a Dependabot bump of `actions/checkout` referenced inside this same workflow), the validation fails with a 401 "Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch."

Excluding `.github/**` from the trigger means self-modifying PRs don't invoke the action at all, sidestepping the 401 entirely.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"` exits 0.
- [ ] On the next PR that touches a non-`.github/**` path, confirm the review job still runs.
- [ ] On a PR that touches only `.github/**`, confirm the review job is skipped (no 401).