### PR TITLE
ci: migrate claude review workflows to dustfeather/shared-workflows@v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,13 +3,15 @@ name: Claude Code Review
 on:
     pull_request:
         types: [opened, synchronize]
-        # Avoid the claude-code-action self-modify validation guard tripping
-        # on PRs that change this very file. Narrow path — broader filters
-        # like '.github/**' would skip review on unrelated workflow PRs.
         paths-ignore:
             - '.github/workflows/claude-code-review.yml'
 
 jobs:
     review:
+        permissions:
+            contents: read
+            pull-requests: write
+            issues: read
+            id-token: write
         uses: dustfeather/shared-workflows/.github/workflows/claude-code-review.yml@v1
         secrets: inherit

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,56 +1,15 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    paths-ignore:
-      - '.github/**'
+    pull_request:
+        types: [opened, synchronize]
+        # Avoid the claude-code-action self-modify validation guard tripping
+        # on PRs that change this very file. Narrow path — broader filters
+        # like '.github/**' would skip review on unrelated workflow PRs.
+        paths-ignore:
+            - '.github/workflows/claude-code-review.yml'
 
 jobs:
-  claude-review:
-    if: github.actor == 'dustfeather' || github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "dependabot[bot]"
-          prompt: |
-            Review pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
-
-            First decide which review track applies:
-
-            DEPENDABOT TRACK — if the PR author is "dependabot[bot]":
-              - Read the PR title, body, and diff with `gh pr view ${{ github.event.pull_request.number }}` and `gh pr diff ${{ github.event.pull_request.number }}`.
-              - Identify whether the bump is patch, minor, or major.
-              - Skim the linked release notes / changelog from the PR body for breaking changes.
-              - Check that the diff is limited to manifest + lockfile (no unrelated source changes).
-              - Decision rules:
-                  • Patch: approve unless the changelog explicitly calls out a breaking change in this version.
-                  • Minor: approve if changelog has no "breaking" / "BREAKING CHANGE" / removed-API language; otherwise request changes.
-                  • Major: request changes by default and ask for human review unless the changelog is unambiguously additive (rare).
-                  • Group PRs (multiple bumps): apply the strictest rule across all members.
-                  • If diff touches anything beyond lockfile + manifest: request changes.
-              - Submit the formal review with the gh CLI (NOT a plain comment):
-                  gh pr review ${{ github.event.pull_request.number }} --approve --body "<one-sentence reasoning>"
-                  OR
-                  gh pr review ${{ github.event.pull_request.number }} --request-changes --body "<what needs human attention>"
-
-            STANDARD TRACK — for any other author:
-              - Do a normal code review: correctness, security, tests, readability.
-              - Leave inline comments via mcp__github_inline_comment__create_inline_comment for specific issues.
-              - Submit a top-level review summary with `gh pr review --comment --body "..."`. Do NOT auto-approve human PRs.
-
-            Be terse. No emoji. No filler.
-          claude_args: '--allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(gh api:*)"'
+    review:
+        uses: dustfeather/shared-workflows/.github/workflows/claude-code-review.yml@v1
+        secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,40 +1,16 @@
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+    issue_comment:
+        types: [created]
+    pull_request_review_comment:
+        types: [created]
+    issues:
+        types: [opened, assigned]
+    pull_request_review:
+        types: [submitted]
 
 jobs:
-  claude:
-    if: |
-      github.actor == 'dustfeather' &&
-      (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    claude:
+        uses: dustfeather/shared-workflows/.github/workflows/claude.yml@v1
+        secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,5 +12,11 @@ on:
 
 jobs:
     claude:
+        permissions:
+            contents: read
+            pull-requests: read
+            issues: read
+            id-token: write
+            actions: read
         uses: dustfeather/shared-workflows/.github/workflows/claude.yml@v1
         secrets: inherit


### PR DESCRIPTION
## Summary

Replaces the inline `claude-code-review.yml` and `claude.yml` workflows with thin shim calls into the centralized reusable workflow at [`dustfeather/shared-workflows@v1`](https://github.com/dustfeather/shared-workflows/tree/v1/.github/workflows).

The central workflow preserves all prior behavior: the existing review prompt, the `dependabot[bot]` allowlist, the `dustfeather` trusted-actor gate, and `show_full_output: true`. Future updates roll out via tagging in the central repo, so this repo stops carrying its own copy.

## Notes

- `secrets: inherit` passes `CLAUDE_CODE_OAUTH_TOKEN` (and any future shared secrets) through to the called workflow unchanged — no re-plumbing required.
- The `paths-ignore` on `claude-code-review.yml` is intentionally narrow (this file only) so that the `claude-code-action` self-modify workflow-validation guard doesn't trip on PRs that touch this very file. A broader `.github/**` filter would silently skip review on unrelated workflow PRs.
- Indentation matches the rest of `.github/workflows/` (4-space).

## Test plan

- [ ] Confirm this PR itself triggers the centralized review workflow (look for the "Claude Code Review / review" check).
- [ ] After merge, verify the next Dependabot PR is picked up by the new shim and the review posts as before.
- [ ] Verify `@claude` mentions on issues / PR review comments still trigger the central `claude.yml` workflow.