### PR TITLE
ci: repoint publish workflows from extension-workflows to shared-workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,14 +107,14 @@ jobs:
 
     publish-chrome:
         needs: build
-        uses: dustfeather/extension-workflows/.github/workflows/publish-chrome.yml@v1
+        uses: dustfeather/shared-workflows/.github/workflows/publish-chrome.yml@v1
         with:
             zip-name: filelist-tv-monitor-chrome-${{ needs.build.outputs.tag }}.zip
         secrets: inherit
 
     publish-firefox:
         needs: build
-        uses: dustfeather/extension-workflows/.github/workflows/publish-firefox.yml@v1
+        uses: dustfeather/shared-workflows/.github/workflows/publish-firefox.yml@v1
         with:
             xpi-name: filelist-tv-monitor-firefox-${{ needs.build.outputs.tag }}.xpi
             source-name: source-${{ needs.build.outputs.tag }}.zip


### PR DESCRIPTION
## Summary

- `extension-workflows` repo is being subsumed by `dustfeather/shared-workflows`. All reusable workflows now live in one place.
- `publish-chrome.yml` and `publish-firefox.yml` are byte-identical copies on the `shared-workflows@v1` tag (specifically `v1.2.0`), so this is a pure URL-string change with no functional impact.
- After this merges, `extension-workflows` will be archived.

## Test plan

- [ ] Confirm release.yml YAML still parses
- [ ] Confirm the next release run fetches the workflow from `dustfeather/shared-workflows@v1` and publishes successfully