### PR TITLE
ci: bump Node to 24 and gate publish on central tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
             - uses: actions/setup-node@v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
 
             - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,13 @@ env:
     FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+    tests:
+        permissions:
+            contents: read
+        uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v1
+
     build:
+        needs: tests
         runs-on: ubuntu-latest
         outputs:
             version: ${{ steps.version.outputs.version }}
@@ -31,7 +37,7 @@ jobs:
 
             - uses: actions/setup-node@v6
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: pnpm
 
             - run: pnpm install --frozen-lockfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+    pull_request:
+        branches: [main]
+
+permissions:
+    contents: read
+
+concurrency:
+    group: tests-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    tests:
+        permissions:
+            contents: read
+        uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v1


### PR DESCRIPTION
## Summary
- Bumps every `setup-node` pin in `build.yml` and `release.yml` from Node 22 to Node 24 (no `.nvmrc`, `.node-version`, or `package.json#engines.node` present in this repo).
- Adds `.github/workflows/tests.yml` that calls `dustfeather/shared-workflows/.github/workflows/node-test.yml@v1` on every PR to `main` (auto-detects pnpm, defaults to Node 24, skips checks when the matching `package.json` script is absent).
- Adds a `tests` job to `release.yml` that runs the same central workflow, and gates `build` on it via `needs: tests`. The existing `publish-chrome` and `publish-firefox` jobs already `needs: build`, so they are now transitively gated on tests.

This repo currently exposes no `lint`/`test`/`typecheck` scripts (typecheck is implicit in `pnpm run build`), so the central workflow will no-op those steps with notices today. Wiring the gate now means future-added scripts are picked up automatically.

## Test plan
- [ ] Tests workflow runs on this PR and reports notices (no `lint`/`test`/`typecheck` scripts in `package.json`).
- [ ] Build workflow runs on Node 24 and produces the `extension-dist` artifact.
- [ ] After merge, `release.yml` runs `tests` first, then `build`, then `publish-chrome` / `publish-firefox`.