### PR TITLE
chore: bump shared-workflows reusable workflows to v4

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,7 +18,7 @@ jobs:
             issues: read
             id-token: write
             actions: read
-        uses: dustfeather/shared-workflows/.github/workflows/claude.yml@v3
+        uses: dustfeather/shared-workflows/.github/workflows/claude.yml@v4
         with:
           runner: arc-df-filelist-ext
         secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,6 +12,6 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
-        uses: dustfeather/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v3
+        uses: dustfeather/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v4
         with:
           runner: arc-df-filelist-ext

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
         if: github.event.action != 'closed'
         permissions:
             contents: read
-        uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v3
+        uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v4
         with:
             runner: arc-df-filelist-ext
             run-build: true
@@ -33,7 +33,7 @@ jobs:
             pull-requests: write
             issues: read
             id-token: write
-        uses: dustfeather/shared-workflows/.github/workflows/claude-code-review.yml@v3
+        uses: dustfeather/shared-workflows/.github/workflows/claude-code-review.yml@v4
         with:
             runner: arc-df-filelist-ext
         secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     tests:
         permissions:
             contents: read
-        uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v3
+        uses: dustfeather/shared-workflows/.github/workflows/node-test.yml@v4
         with:
           runner: arc-df-filelist-ext
 
@@ -115,7 +115,7 @@ jobs:
 
     publish-chrome:
         needs: build
-        uses: dustfeather/shared-workflows/.github/workflows/publish-chrome.yml@v3
+        uses: dustfeather/shared-workflows/.github/workflows/publish-chrome.yml@v4
         with:
             runner: arc-df-filelist-ext
             zip-name: filelist-tv-monitor-chrome-${{ needs.build.outputs.tag }}.zip
@@ -123,7 +123,7 @@ jobs:
 
     publish-firefox:
         needs: build
-        uses: dustfeather/shared-workflows/.github/workflows/publish-firefox.yml@v3
+        uses: dustfeather/shared-workflows/.github/workflows/publish-firefox.yml@v4
         with:
             runner: arc-df-filelist-ext
             xpi-name: filelist-tv-monitor-firefox-${{ needs.build.outputs.tag }}.xpi


### PR DESCRIPTION
Bumps all shared-workflows reusable workflow references from v2/v3 to v4.